### PR TITLE
Replace directory separator for repo directory on Windows

### DIFF
--- a/lib/line-diff-worker.coffee
+++ b/lib/line-diff-worker.coffee
@@ -63,7 +63,7 @@ class LineDiffWorker
 
     findFileDiffs: ->
         activePath = @editor.getPath()
-        repo = r for r in atom.project.getRepositories() when activePath.indexOf(r?.repo.workingDirectory) != -1
+        repo = r for r in atom.project.getRepositories() when activePath.indexOf(r?.repo.workingDirectory.replace(/\//g, "\\")) != -1
         return [] if not repo?
         fileRepo = repo.getRepo(activePath)
         activeEditorText = @editor.getBuffer().getText()


### PR DESCRIPTION
Fix for #7 

Please test on other OS too.