### PR TITLE
Now close is red (classic) and copy is green to match the pop-up generated by using it

### DIFF
--- a/lib/line-diff-worker.coffee
+++ b/lib/line-diff-worker.coffee
@@ -141,11 +141,11 @@ class MessageBubble extends View
         @div class: "bubble", =>
             @div class: "action-buttons", =>
                 @button click: "removeView", class: "btn diff-button", title: "Close", =>
-                    @span class: "text-success icon icon-x"
+                    @span class: "text-error icon icon-x"
                 @button click: "revertAndClose", class: "btn diff-button", title: "Revert", =>
                     @span class: "text-warning icon icon-history"
                 unless isRemoval
                     @button click: "copyToClipboard", class: "btn diff-button", title: "Copy", =>
-                        @span class: "text-primary icon icon-clippy"
+                        @span class: "text-success icon icon-clippy"
             @div class: "bubble-code", => @span message
 module.exports = LineDiffWorker


### PR DESCRIPTION
<img width="692" alt="screen shot 2016-05-19 at 7 50 58 pm" src="https://cloud.githubusercontent.com/assets/2745502/15413084/1b94e87a-1dfb-11e6-9e63-88e77d56779d.png">
