### PR TITLE
Fix issues indicated by coffeelint

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,11 @@
+{
+  "indentation": {
+    "value": 4
+  },
+  "max_line_length": {
+    "level": "ignore"
+  },
+  "ensure_comprehensions": {
+    "level": "ignore"
+  }
+}

--- a/lib/line-diff-worker.coffee
+++ b/lib/line-diff-worker.coffee
@@ -46,11 +46,11 @@ class LineDiffWorker
         messageBubble = null
         marker = @editor.markBufferRange([startPoint, startPoint], {name: "line-diff"})
         if details.isRemoving
-            messageBubble = new MessageBubble(details.originalContent, =>
+            messageBubble = new MessageBubble(details.originalContent, ->
                 buffer.insert([details.newStart, 0], details.originalContent)
             )
         else if details.isAdding
-            messageBubble = new MessageBubble(details.originalContent, =>
+            messageBubble = new MessageBubble(details.originalContent, ->
                 buffer.deleteRows(details.newStart - 1, newEndBufferRow)
             )
         else

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.3"
+  },
+  "devDependencies": {
+    "coffeelint": "1.16.0"
   }
 }


### PR DESCRIPTION
With this change in place it is now possible to open
line-diff-worker.coffee in Atom, and have the Coffeelint plugin not
warn about anything.

Additionally, the code will be kept Coffeelint clean using Travis.