### PR TITLE
Use the editor font for showing diffs

### DIFF
--- a/styles/atom-overlay.less
+++ b/styles/atom-overlay.less
@@ -10,15 +10,18 @@
   width: auto;
   padding: 10px;
   border-radius: 3px;
-  
+
   .bubble-code {
     line-height: 18px;
     color: #f6f6f6;
     white-space: pre-wrap;
     padding: 5px;
     margin-top: 5px;
+
+    // Copied from https://github.com/atom/atom/blob/master/static/text-editor-light.less
+    font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
   }
-  
+
   .diff-button {
     margin-right: 5px;
     text-align: center;


### PR DESCRIPTION
Before this change, the diffs were shown using a proportional font,
which looked strange given that that's not what the editor is using.

With this change:
![skarmavbild 2016-12-16 kl 22 30 42](https://cloud.githubusercontent.com/assets/158201/21279161/295554a6-c3df-11e6-9a21-f6cb452f5537.png)

Without this change:
![skarmavbild 2016-12-16 kl 22 31 06](https://cloud.githubusercontent.com/assets/158201/21279167/2faecd3c-c3df-11e6-8816-f0fe6aaf4f34.png)
