### PR TITLE
Fix a shutdown crash

### DIFF
--- a/lib/line-diff-details.ts
+++ b/lib/line-diff-details.ts
@@ -1,4 +1,6 @@
-var LineDiffWorker = require("./line-diff-worker")
+import $ = require("jquery")
+
+import LineDiffWorker = require("./line-diff-worker")
 
 class LineDiffDetails {
     activate(): void {


### PR DESCRIPTION
Add a forgotten-about import in the TypeScript source code.

That import is only accessed during deactivation, so unless you have
your console open when you shut down you wouldn't see the I-don't-know-
what-$-is crash.