### PR TITLE
Destroy MessageBubbles on cursor change

### DIFF
--- a/lib/line-diff-worker.coffee
+++ b/lib/line-diff-worker.coffee
@@ -4,6 +4,7 @@ class LineDiffWorker
     registerEditor: (@editor) ->
         @editor.onDidChangeScrollTop @update
         @editor.onDidStopChanging @update
+        @editor.onDidChangeCursorPosition @clearMarkers
 
     update: =>
         @clearMarkers()
@@ -32,7 +33,7 @@ class LineDiffWorker
             details = @calculateDiffDetails(line)
             @decorateDiffMarkers(details)
 
-    clearMarkers: ->
+    clearMarkers: =>
         markers = @editor.findMarkers({name: "line-diff"})
         marker.destroy() for marker in markers
 

--- a/spec/line-diff-worker-spec.coffee
+++ b/spec/line-diff-worker-spec.coffee
@@ -99,15 +99,18 @@ describe "LineDiffWorker Suite", ->
         scrollTopEvent = no
         stopChangingEvent = no
         pathChangeEvent = no
+        changeCursorPositionEvent = no
         editor = {
             onDidChangeScrollTop: -> scrollTopEvent = yes
             onDidStopChanging: -> stopChangingEvent = yes
+            onDidChangeCursorPosition: -> changeCursorPositionEvent = yes
         }
 
         service.registerEditor(editor)
 
         expect(scrollTopEvent).toBe yes
         expect(stopChangingEvent).toBe yes
+        expect(changeCursorPositionEvent).toBe yes
 
     it "should decorate the marker", ->
         decorated = no


### PR DESCRIPTION
This way it behaves more like other similar atom's widgets e.g.
autocomplete-suggestion. It's also nicer ux.