### PR TITLE
don't try to force a font-family to the bubble

### DIFF
--- a/styles/atom-overlay.less
+++ b/styles/atom-overlay.less
@@ -5,7 +5,7 @@
   box-shadow: 0px 0px 20px 0px @syntax-text-color;
   left: 3px;
   background: rgba(33, 38, 38, 0.92);
-  font-family: @font-family;
+  font-family: inherit;
   font-size: @font-size;
   width: auto;
   padding: 10px;
@@ -17,9 +17,6 @@
     white-space: pre-wrap;
     padding: 5px;
     margin-top: 5px;
-
-    // Copied from https://github.com/atom/atom/blob/master/static/text-editor-light.less
-    font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
   }
 
   .diff-button {


### PR DESCRIPTION
You are trying to force a font-family to the editor by loading the default font-family in `.bubble` and `.bubble-code`. The previous approach would only work with an editor that didn't have it's font changed.